### PR TITLE
fix: color del texto de seguridad bajo el CTA para tema claro

### DIFF
--- a/src/components/call-to-action.astro
+++ b/src/components/call-to-action.astro
@@ -45,9 +45,9 @@ import { siteConfig } from '~/config/site.config';
   }
   .cta-subtext {
     text-align: center;
-    color: rgba(255, 255, 255, 0.85);
+    color: #4b5563;
     font-size: 0.875rem;
-    font-weight: 500;
+    font-weight: 600;
     max-width: 380px;
     line-height: 1.4;
   }


### PR DESCRIPTION
El subtexto "100% Gratis · Solo 100 cupos · Sin spam" estaba en blanco y no se veía sobre el fondo crema. Lo cambio a gris oscuro con peso 600.